### PR TITLE
lock using the cache key instead of a global lock

### DIFF
--- a/src/main/java/com/arhs/spring/cache/mongo/MongoCache.java
+++ b/src/main/java/com/arhs/spring/cache/mongo/MongoCache.java
@@ -67,8 +67,6 @@ public class MongoCache implements Cache {
     private final MongoTemplate mongoTemplate;
     private final long ttl;
 
-    private final Object lock = new Object();
-
     /**
      * Constructor.
      *
@@ -168,7 +166,9 @@ public class MongoCache implements Cache {
             return (T) cached;
         }
 
-        synchronized (lock) {
+        final Object dynamicLock = ((String) key).intern();
+
+        synchronized (dynamicLock) {
             cached = getFromCache(key);
             if (cached != null) {
                 return (T) cached;


### PR DESCRIPTION
Lock using the cache key instead of a global lock, which allows more concurrency without race conditions.